### PR TITLE
fix warning flatList and border for multiline input

### DIFF
--- a/src/app/components/CustomTextInput/styles.ts
+++ b/src/app/components/CustomTextInput/styles.ts
@@ -4,6 +4,8 @@ import { blue, gray, darkGray, red, white } from '@constants/colors';
 import { SIZES } from '@constants/fonts';
 import { commonBoxShadow } from '@constants/commonStyles';
 
+const DEFAULT_BORDER = 15;
+
 export default StyleSheet.create({
   container: {
     marginBottom: 5,
@@ -16,6 +18,7 @@ export default StyleSheet.create({
     height: 75,
     paddingHorizontal: 5,
     backgroundColor: white,
+    borderRadius: DEFAULT_BORDER,
     ...commonBoxShadow
   },
   inputContainer: {
@@ -26,7 +29,7 @@ export default StyleSheet.create({
     justifyContent: 'space-between',
     backgroundColor: white,
     height: 50,
-    borderRadius: 15,
+    borderRadius: DEFAULT_BORDER,
     ...commonBoxShadow,
     alignSelf: 'center',
     paddingHorizontal: 8

--- a/src/app/screens/NewArticle/index.tsx
+++ b/src/app/screens/NewArticle/index.tsx
@@ -44,87 +44,93 @@ function NewArticle() {
   }, [items, setValue]);
 
   return (
-    <View style={styles.container}>
-      <KeyboardAwareScrollView bounces={false} enableOnAndroid>
-        <CustomText green bold style={styles.title}>
-          Create article
-        </CustomText>
-        <ControlledCustomTextInput
-          testIDProp={testIds.titleInput}
-          control={control}
-          label={i18next.t('NEW_ARTICLE:TITLE')}
-          name={FIELDS.title}
-          placeholder={i18next.t('NEW_ARTICLE:PLACEHODER_TITLE')}
-          labelStyle={styles.labelStyle}
-          rules={{
-            ...validateRequired,
-            ...validateMinLength(MIN_LENGHT_FIELD),
-            ...validateMaxLength(MAX_TITLE_LENGHT),
-            ...validateAlphanumeric
-          }}
-          maxLength={MAX_TITLE_LENGHT}
-        />
-        <ControlledCustomTextInput
-          testIDProp={testIds.descriptionInput}
-          control={control}
-          labelStyle={styles.labelStyle}
-          label={i18next.t('NEW_ARTICLE:DESCRIPTION')}
-          name={FIELDS.description}
-          placeholder={i18next.t('NEW_ARTICLE:PLACEHOLDER_DESCRIPTION')}
-          rules={{
-            ...validateRequired,
-            ...validateMinLength(MIN_LENGHT_FIELD),
-            ...validateMaxLength(MAX_DESCRIPTION_LENGHT),
-            ...validateAlphanumeric
-          }}
-          maxLength={MAX_DESCRIPTION_LENGHT}
-        />
+    <FlatList
+      renderItem={null}
+      data={null}
+      ListHeaderComponent={
+        <View style={styles.container}>
+          <KeyboardAwareScrollView bounces={false} enableOnAndroid>
+            <CustomText green bold style={styles.title}>
+              Create article
+            </CustomText>
+            <ControlledCustomTextInput
+              testIDProp={testIds.titleInput}
+              control={control}
+              label={i18next.t('NEW_ARTICLE:TITLE')}
+              name={FIELDS.title}
+              placeholder={i18next.t('NEW_ARTICLE:PLACEHODER_TITLE')}
+              labelStyle={styles.labelStyle}
+              rules={{
+                ...validateRequired,
+                ...validateMinLength(MIN_LENGHT_FIELD),
+                ...validateMaxLength(MAX_TITLE_LENGHT),
+                ...validateAlphanumeric
+              }}
+              maxLength={MAX_TITLE_LENGHT}
+            />
+            <ControlledCustomTextInput
+              testIDProp={testIds.descriptionInput}
+              control={control}
+              labelStyle={styles.labelStyle}
+              label={i18next.t('NEW_ARTICLE:DESCRIPTION')}
+              name={FIELDS.description}
+              placeholder={i18next.t('NEW_ARTICLE:PLACEHOLDER_DESCRIPTION')}
+              rules={{
+                ...validateRequired,
+                ...validateMinLength(MIN_LENGHT_FIELD),
+                ...validateMaxLength(MAX_DESCRIPTION_LENGHT),
+                ...validateAlphanumeric
+              }}
+              maxLength={MAX_DESCRIPTION_LENGHT}
+            />
 
-        <ControlledCustomTextInput
-          testIDProp={testIds.bodyInput}
-          control={control}
-          multiline
-          label={i18next.t('NEW_ARTICLE:BODY')}
-          labelStyle={styles.labelStyle}
-          name={FIELDS.body}
-          placeholder={i18next.t('NEW_ARTICLE:PLACEHOLDER_BODY')}
-          rules={{
-            ...validateRequired,
-            ...validateMinLength(MIN_LENGHT_FIELD),
-            ...validateMaxLength(MAX_BODY_LENGHT)
-          }}
-          maxLength={MAX_BODY_LENGHT}
-        />
+            <ControlledCustomTextInput
+              testIDProp={testIds.bodyInput}
+              control={control}
+              multiline
+              label={i18next.t('NEW_ARTICLE:BODY')}
+              labelStyle={styles.labelStyle}
+              name={FIELDS.body}
+              placeholder={i18next.t('NEW_ARTICLE:PLACEHOLDER_BODY')}
+              rules={{
+                ...validateRequired,
+                ...validateMinLength(MIN_LENGHT_FIELD),
+                ...validateMaxLength(MAX_BODY_LENGHT)
+              }}
+              maxLength={MAX_BODY_LENGHT}
+            />
 
-        <ControlledCustomTextInput
-          testIDProp={testIds.tagInput}
-          control={control}
-          labelStyle={styles.labelStyle}
-          label={i18next.t('NEW_ARTICLE:TAGS')}
-          name={'addTag'}
-          placeholder={i18next.t('NEW_ARTICLE:PLACHEHOLDER_TAGS')}
-          onSubmitEditing={({ nativeEvent: { text } }) => {
-            if (text.length >= MIN_LENGTH_TAG) setItems([...items, text]);
-          }}
-        />
-        <>
-          <FlatList
-            numColumns={2}
-            columnWrapperStyle={styles.row}
-            data={items}
-            keyExtractor={(item, index) => `${item}${index}`}
-            renderItem={renderItem}
-          />
-        </>
-        <CustomButton
-          testID={testIds.createArticleButton}
-          primary
-          onPress={handleSubmit(handleNewArticle)}
-          title={i18next.t('NEW_ARTICLE:CREATE_BUTTON')}
-          style={styles.createButton}
-        />
-      </KeyboardAwareScrollView>
-    </View>
+            <ControlledCustomTextInput
+              testIDProp={testIds.tagInput}
+              control={control}
+              labelStyle={styles.labelStyle}
+              label={i18next.t('NEW_ARTICLE:TAGS')}
+              name={'addTag'}
+              placeholder={i18next.t('NEW_ARTICLE:PLACHEHOLDER_TAGS')}
+              onSubmitEditing={({ nativeEvent: { text } }) => {
+                if (text.length >= MIN_LENGTH_TAG) setItems([...items, text]);
+              }}
+            />
+            <View style={styles.containerList}>
+              <FlatList
+                numColumns={2}
+                columnWrapperStyle={styles.row}
+                data={items}
+                keyExtractor={(item, index) => `${item}${index}`}
+                renderItem={renderItem}
+              />
+            </View>
+            <CustomButton
+              testID={testIds.createArticleButton}
+              primary
+              onPress={handleSubmit(handleNewArticle)}
+              title={i18next.t('NEW_ARTICLE:CREATE_BUTTON')}
+              style={styles.createButton}
+            />
+          </KeyboardAwareScrollView>
+        </View>
+      }
+    />
   );
 }
 

--- a/src/app/screens/NewArticle/styles.ts
+++ b/src/app/screens/NewArticle/styles.ts
@@ -16,6 +16,9 @@ export default StyleSheet.create({
     color: green,
     marginVertical: 5
   },
+  containerList: {
+    marginBottom: DEFAULT_SPACE
+  },
   row: {
     flex: 1,
     justifyContent: 'space-around'


### PR DESCRIPTION
There was a warning in the new article creation view and the border of the multiline input

BEFORE             |  AFTER
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/87880658/127694404-54557c70-b44d-4a72-9339-207145a4d712.gif)  |  ![](https://user-images.githubusercontent.com/87880658/127694435-ec67e154-0aea-4438-9cfc-4a9b81fa3888.gif)

## Trello Card
https://trello.com/b/MfQu2HoL/conduit
